### PR TITLE
Don't install Python on Jenkins

### DIFF
--- a/bin/install-python.sh
+++ b/bin/install-python.sh
@@ -24,6 +24,13 @@ then
   exit
 fi
 
+# Exit if we're running on Jenkins.
+# On Jenkins we run the tests in Docker and we just want to use the versions of
+# Python provided in the Docker container.
+if [ -n "${JENKINS_URL+set}" ]; then
+  exit
+fi
+
 # Loop over every $python_version in the .python-version file.
 while IFS= read -r python_version
 do


### PR DESCRIPTION
I don't know that we're going to be using Jenkins or Travis for packages, but the `install-python` script in this repo already had our Travis escape hatch in it so add the Jenkins one too. We probably want a similar pyenv escape hatch for GitHub Actions too. As long as we're still using Jenkins and Travis for at least some of our projects (at least some of the apps do) I think this script might as well just contain both escape hatches just for the sake of making the script exactly the same for all projects.