### PR TITLE
Add tox-envfile tox plugin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 3.8.0
 requires =
   tox-pip-extensions
   tox-pyenv
+  tox-envfile
   tox-run-command
 tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false


### PR DESCRIPTION
Some of our apps need this tox plugin:

https://github.com/seanh/tox-envfile

I don't know that any of our libs are going to need it, but we may as well put it here just in case, and to reduce tox.ini differences between projects. It shouldn't do any harm.