### PR TITLE
Install isort with requirements.txt support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     {tests,lint}: .[tests]
     lint: pylint
     {checkformatting,format}: black
-    {checkformatting,format}: isort
+    {checkformatting,format}: isort[requirements]
     coverage: coverage
     {package,publish}: twine
     package: wheel


### PR DESCRIPTION
Our apps need this. I'm not sure our libraries need this yet (they don't list their requirements in requirements.txt) but I suspect they might do in future, and we may as well put this here just to reduce tox.ini differences between apps and libs, it shouldn't do any harm.