### PR TITLE
Fix `make lint` on fresh projects

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     coverage: coverage
     {package,publish}: twine
     package: wheel
-    replay-cookiecutter: cookiecutter
+    {lint,replay-cookiecutter}: cookiecutter
 whitelist_externals =
     package: rm
 commands =


### PR DESCRIPTION
If you use the cookiecutter to create a brand new project and then run `make lint` pylint warns because it doesn't know what cookiecutter is.