### PR TITLE
Remove echo noise

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,13 +25,10 @@ deps =
     package: wheel
     replay-cookiecutter: cookiecutter
 whitelist_externals =
-    lint: echo
     package: rm
 commands =
     tests: coverage run -m pytest
-    lint: echo "Checking main code..."
     lint: pylint {posargs:h_cookiecutter_pypackage bin}
-    lint: echo "Checking tests..."
     lint: pylint --rcfile=tests/.pylintrc tests
     format: black {posargs:h_cookiecutter_pypackage tests bin}
     format: isort --recursive --quiet --atomic .


### PR DESCRIPTION
I've found in the past that people have complained about commands that print too much "noisy" output, so the general style has been for commands not to print more than they need to.