### PR TITLE
Remove silenced warning from pytest.ini

### DIFF
--- a/{{ cookiecutter.project_slug }}/pytest.ini
+++ b/{{ cookiecutter.project_slug }}/pytest.ini
@@ -2,6 +2,3 @@
 filterwarnings =
     # Fail the tests if there are any warnings.
     error
-
-    # Silence an imp warning that venusian is triggering.
-    ignore:^the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses$:DeprecationWarning:venusian


### PR DESCRIPTION
The warnings to be silenced are going to vary from one project to the next.