### PR TITLE
Add a missing __init__.py file

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,7 +36,7 @@ jobs:
       continue-on-error: true
       run: |
         pip install pytest pytest-html coverage
-        coverage run -m pytest --html=unit_test_report.html --self-contained-html
+        coverage run -m pytest --html=unit_test_report.html --self-contained-html tests
         touch unit_tests_passed
 
     - name: Archive unit test report

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
 whitelist_externals =
     package: rm
 commands =
-    tests: coverage run -m pytest
+    tests: coverage run -m pytest tests
     lint: pylint {posargs:h_cookiecutter_pypackage bin}
     lint: pylint --rcfile=tests/.pylintrc tests
     format: black {posargs:h_cookiecutter_pypackage tests bin}


### PR DESCRIPTION
`make lint` was failing in newly cookiecutter'ed projects because this file was missing.

Also fixed the pytest command in tox.ini so that the existence of this file doesn't break the tests.