### PR TITLE
Pylint tweaks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,16 @@
+[MASTER]
+jobs=0  # Speed up PyLint by using one process per CPU core.
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.comparetozero,
+             pylint.extensions.docparams,
+             pylint.extensions.emptystring,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.redefined_variable_type,
+
+[MESSAGES CONTROL]
+disable=bad-continuation,
+
+[REPORTS]
+output-format=colorized
+score=no

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,8 @@ load-plugins=pylint.extensions.bad_builtin,
 
 [MESSAGES CONTROL]
 disable=bad-continuation,
+        missing-type-doc,
+        missing-return-type-doc,
 
 [REPORTS]
 output-format=colorized

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ clean:
 
 .PHONY: python
 python:
-	@./bin/install-python
+	@./bin/install-python.sh

--- a/bin/install-python.sh
+++ b/bin/install-python.sh
@@ -13,7 +13,7 @@
 # Usage
 # =====
 #
-# $ ./bin/install-python
+# $ ./bin/install-python.sh
 
 # Exit if we're running on Travis CI.
 # On Travis we just want to use the versions of Python provided in the Travis

--- a/bin/replay_cookie_cutter.py
+++ b/bin/replay_cookie_cutter.py
@@ -29,9 +29,21 @@ class CookieCutter:
         will be used to decide which template to replay if none is provided.
 
         :param project_dir: The target directory
+        :type project_dir: str
+
         :param config: The config to apply
+        :type config: dict
+
         :param template: The template to apply
+        :type template: str
+
         :return: The name of the project created
+        :rtype: str
+
+        :raise ValueError: If cookiecutter replaying would change the
+            name of the project (the name of the project created by replaying
+            the cookiecutter project template is different from the currently
+            existing name of the project)
         """
         project_dir = os.path.abspath(project_dir)
         disable_replay = config.get("options", {}).get("disable_replay")
@@ -43,7 +55,7 @@ class CookieCutter:
             current_name = os.path.basename(project_dir)
 
             if project_name != current_name:
-                raise EnvironmentError(
+                raise ValueError(
                     "The project created does not match the project directory: "
                     f"Created {project_name}, existing {current_name}"
                 )
@@ -105,9 +117,16 @@ class CookieCutter:
         will be used to decide which template to replay if none is provided.
 
         :param project_dir: The target directory
+        :type project_dir: str
+
         :param config: The config to apply
+        :type config: dict
+
         :param template: The template to apply
+        :type template: str
+
         :return: The name of the project created
+        :rtype: str
         """
         if template is None:
             template = cls.get_template_from_config(config)

--- a/bin/replay_cookie_cutter.py
+++ b/bin/replay_cookie_cutter.py
@@ -29,16 +29,12 @@ class CookieCutter:
         will be used to decide which template to replay if none is provided.
 
         :param project_dir: The target directory
-        :type project_dir: str
 
         :param config: The config to apply
-        :type config: dict
 
         :param template: The template to apply
-        :type template: str
 
         :return: The name of the project created
-        :rtype: str
 
         :raise ValueError: If cookiecutter replaying would change the
             name of the project (the name of the project created by replaying
@@ -117,16 +113,12 @@ class CookieCutter:
         will be used to decide which template to replay if none is provided.
 
         :param project_dir: The target directory
-        :type project_dir: str
 
         :param config: The config to apply
-        :type config: dict
 
         :param template: The template to apply
-        :type template: str
 
         :return: The name of the project created
-        :rtype: str
         """
         if template is None:
             template = cls.get_template_from_config(config)

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -14,6 +14,8 @@ disable=bad-continuation,
         missing-function-docstring,
         missing-module-docstring,
         missing-class-docstring,
+        missing-type-doc,
+        missing-return-type-doc,
         no-self-use,
         redefined-outer-name,
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -1,2 +1,22 @@
+[MASTER]
+jobs=0  # Speed up PyLint by using one process per CPU core.
+load-plugins=pylint.extensions.bad_builtin,
+             pylint.extensions.check_elif,
+             pylint.extensions.comparetozero,
+             pylint.extensions.docparams,
+             pylint.extensions.emptystring,
+             pylint.extensions.overlapping_exceptions,
+             pylint.extensions.redefined_variable_type,
+
 [MESSAGES CONTROL]
-disable=missing-function-docstring, missing-module-docstring, missing-class-docstring,no-self-use
+disable=bad-continuation,
+        invalid-name,
+        missing-function-docstring,
+        missing-module-docstring,
+        missing-class-docstring,
+        no-self-use,
+        redefined-outer-name,
+
+[REPORTS]
+output-format=colorized
+score=no

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -117,7 +117,7 @@ class TestCookieCutter:
         new_name = os.path.join(tmp_path, "something_new")
         shutil.move(existing_project, new_name)
 
-        with pytest.raises(EnvironmentError):
+        with pytest.raises(ValueError):
             CookieCutter.replay(project_dir=new_name, config=config)
 
     @pytest.fixture

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -76,7 +76,7 @@ class TestCookieCutter:
             output_dir=tmp_path,
         )
 
-    def test_it_can_replay_template(self, tmp_path, existing_project, config):
+    def test_it_can_replay_template(self, existing_project, config):
         # Mess with it
         setup_py = os.path.join(existing_project, "setup.py")
         os.unlink(setup_py)

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -10,7 +10,7 @@ from bin.replay_cookie_cutter import CookieCutter, run
 
 
 class TestScript:
-    def test_sanity(self, PARSER, CookieCutter, config):
+    def test_sanity(self, CookieCutter, config):
         # This is unfortunately kind of a one and done test
         # It hits everything it needs to in one go (json, args, calls)
         run()
@@ -31,7 +31,7 @@ class TestScript:
 
         return filename
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def PARSER(self, patch, config_file):
         PARSER = patch("bin.replay_cookie_cutter.PARSER")
 

--- a/{{ cookiecutter.project_slug }}/.pylintrc
+++ b/{{ cookiecutter.project_slug }}/.pylintrc
@@ -1,0 +1,1 @@
+../.pylintrc

--- a/{{ cookiecutter.project_slug }}/bin/install-python
+++ b/{{ cookiecutter.project_slug }}/bin/install-python
@@ -1,1 +1,0 @@
-../../bin/install-python

--- a/{{ cookiecutter.project_slug }}/bin/install-python.sh
+++ b/{{ cookiecutter.project_slug }}/bin/install-python.sh
@@ -1,0 +1,1 @@
+../../bin/install-python.sh


### PR DESCRIPTION
Various pylint-related tweaks:

* Make it use all CPUs in parallel to run faster
* Enable a bunch of builtin plugins that aren't enabled by default (see https://github.com/hypothesis/h-cookiecutter-pypackage/commit/4db3425ba1ccab7eee0870a94620e7533bc99cad for details)
* Change output format
* Add a second pylintrc file to configure pylint for the non-test code. Unfortunately duplicates the tests/.pylintrc but I think that's unavoidable
* Fix various things about the code that the new pylint plugins complained about