### PR TITLE
Don't use non-tox copy of Black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ commands =
     lint: sh -c "pylint {posargs:$(python setup.py --name) bin}"
     lint: echo "Checking tests..."
     lint: pylint --rcfile=tests/.pylintrc tests
-    format: sh -c "black {posargs:$(python setup.py --name) tests bin}"
+    format: sh -c "{envbindir}/black {posargs:$(python setup.py --name) tests bin}"
     format: isort -y
-    checkformatting: sh -c "black --check {posargs:$(python setup.py --name) tests bin}"
+    checkformatting: sh -c "{envbindir}/black --check {posargs:$(python setup.py --name) tests bin}"
     format: isort --check-only
     coverage: -coverage combine
     coverage: coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,21 @@ deps =
     package: wheel
     replay-cookiecutter: cookiecutter
 whitelist_externals =
-    {lint,format,checkformatting,package}: sh
     lint: echo
+    package: rm
 commands =
     tests: coverage run -m pytest
     lint: echo "Checking main code..."
-    lint: sh -c "pylint {posargs:$(python setup.py --name) bin}"
+    lint: pylint {posargs:h_cookiecutter_pypackage bin}
     lint: echo "Checking tests..."
     lint: pylint --rcfile=tests/.pylintrc tests
-    format: sh -c "{envbindir}/black {posargs:$(python setup.py --name) tests bin}"
+    format: black {posargs:h_cookiecutter_pypackage tests bin}
     format: isort -y
-    checkformatting: sh -c "{envbindir}/black --check {posargs:$(python setup.py --name) tests bin}"
+    checkformatting: black --check {posargs:h_cookiecutter_pypackage tests bin}
     format: isort --check-only
     coverage: -coverage combine
     coverage: coverage report
-    package: sh -c "rm -rf dist *.egg-info"
+    package: rm -rf dist h_cookiecutter_pypackage.egg-info
     package: python setup.py bdist_wheel sdist
     package: twine check dist/*
     publish: twine check dist/*

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -1,1 +1,47 @@
-../tox.ini
+[tox]
+envlist = py36-tests
+skipsdist = true
+minversion = 3.8.0
+requires =
+  tox-pip-extensions
+  tox-pyenv
+  tox-run-command
+tox_pip_extensions_ext_venv_update = true
+tox_pyenv_fallback = false
+
+[testenv]
+skip_install = true
+sitepackages = {env:SITE_PACKAGES:false}
+setenv = dev: PYTHONPATH = .
+passenv =
+    package: BUILD
+deps =
+    {tests,lint}: .[tests]
+    lint: pylint
+    {checkformatting,format}: black
+    {checkformatting,format}: isort
+    coverage: coverage
+    {package,publish}: twine
+    package: wheel
+    replay-cookiecutter: cookiecutter
+whitelist_externals =
+    lint: echo
+    package: rm
+commands =
+    tests: coverage run -m pytest
+    lint: echo "Checking main code..."
+    lint: pylint {posargs:{{ cookiecutter.pkg_name }} bin}
+    lint: echo "Checking tests..."
+    lint: pylint --rcfile=tests/.pylintrc tests
+    format: black {posargs:{{ cookiecutter.pkg_name }} tests bin}
+    format: isort -y
+    checkformatting: black --check {posargs:{{ cookiecutter.pkg_name }} tests bin}
+    format: isort --check-only
+    coverage: -coverage combine
+    coverage: coverage report
+    package: rm -rf dist {{ cookiecutter.pkg_name }}.egg-info
+    package: python setup.py bdist_wheel sdist
+    package: twine check dist/*
+    publish: twine check dist/*
+    publish: twine upload dist/*
+    replay-cookiecutter: python bin/replay_cookie_cutter.py --config .cookiecutter.json --output-directory .


### PR DESCRIPTION
Because we're using sh to run black in tox.ini (rather than having tox
run black directly) sh will run whatever copy of black it finds first on
the user's $PATH. For example if the user has a system-wide copy of
black it will run that instead of tox's copy.

tox will not complain about a non-whitelisted executable from outside of
the virtualenv being executed either, because it's not tox that's
executing this non-virtualenv copy of black, it's sh that's executing
it.

We don't want to execute a copy of black from outside of the virtualenv
because this might not be the right version of black. Right now we don't
care what version of black is used and don't pin the version. But in the
future we might put a === or a >= on the black requirement in tox.ini
which would cause tox to ensure a certain version of black (for example
if a new version of black came out with a bug fix or new feature and we
wanted to auto-upgrade everyone's dev envs to it).

It also just introduces the possibility of the user having a broken or
somehow mis-installed global copy of black and that breaking their dev
env.

Force tox's version of black to be used by prefixing the black command
with tox's {envbindir} substitution (which is the path to the tox
venv's bin dir). See:

https://tox.readthedocs.io/en/latest/config.html#substitutions-for-virtualenv-related-sections