### PR TITLE
Ensuring we preserve executable bit when replaying

### DIFF
--- a/bin/replay_cookie_cutter.py
+++ b/bin/replay_cookie_cutter.py
@@ -106,7 +106,7 @@ class CookieCutter:
                 source = os.path.join(source_dir, rel_path)
 
                 mkpath(os.path.dirname(target))
-                shutil.copyfile(source, target)
+                shutil.copy(source, target)
 
     @classmethod
     def render_template(cls, project_dir, config, template=None):

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -115,6 +115,16 @@ class TestCookieCutter:
         self.assert_file_contains(makefile, "Nonsense")
         self.assert_file_exists(setup_cfg)
 
+    def test_replay_preserves_executable_premissions(self, existing_project, config):
+        executable_file = os.path.join(existing_project, "bin/install-python.sh")
+        # Delete the file first, or we somehow keep permissions
+        os.unlink(executable_file)
+
+        CookieCutter.replay(project_dir=existing_project, config=config)
+
+        assert os.path.isfile(executable_file)
+        assert os.access(executable_file, os.X_OK)
+
     def test_if_fails_when_template_does_not_match_project(
         self, tmp_path, existing_project, config
     ):


### PR DESCRIPTION
Using the wrong shutil copy function (copyfile) only copied the contents, not the permissions. 

This is reproducable by deleting the file in question and then replaying over the top, or by 'replaying' into a fresh project that never had the file.