### PR TITLE
Don't overwrite main package __init__.py on replay

### DIFF
--- a/bin/replay_cookie_cutter.py
+++ b/bin/replay_cookie_cutter.py
@@ -106,7 +106,7 @@ class CookieCutter:
                 source = os.path.join(source_dir, rel_path)
 
                 mkpath(os.path.dirname(target))
-                shutil.copyfile(source, target)
+                shutil.copy(source, target)
 
     @classmethod
     def render_template(cls, project_dir, config, template=None):

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,8 @@
     "options": {
         "disable_replay": [
             "README.md",
-            "setup.cfg"
+            "setup.cfg",
+            "src/{{ cookiecutter.pkg_name }}/__init__.py"
         ]
     }
 }

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -115,6 +115,16 @@ class TestCookieCutter:
         self.assert_file_contains(makefile, "Nonsense")
         self.assert_file_exists(setup_cfg)
 
+    def test_replay_preserves_executable_premissions(self, existing_project, config):
+        executable_file = os.path.join(existing_project, "bin/install-python.sh")
+        # Delete the file first, or we somehow keep permissions
+        os.unlink(executable_file)
+
+        CookieCutter.replay(project_dir=existing_project, config=config)
+
+        assert os.path.isfile(executable_file)
+        assert os.access(executable_file, os.X_OK)
+
     def test_if_fails_when_template_does_not_match_project(
         self, tmp_path, existing_project, config
     ):


### PR DESCRIPTION
Yeah... just don't

I've mistakenly included the executable bit fix here as well. So this will make more sense when the other one is merged in.