### PR TITLE
Cookiecutter is required to lint the bin directory

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
@@ -25,7 +25,7 @@ jobs:
     # so this is as late as we can leave this
     - name: Install dependencies
       run: |
-        pip install .[tests]
+        pip install .[tests] cookiecutter
 
     - name: Lint with pylint
       run: |


### PR DESCRIPTION
We fixed this in tox, but missed gitlab