### PR TITLE
Changing the isort to assume 3rd party and know about the 1st

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,4 +7,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=factory,faker,hypothesis,pytest,webtest
+default_section=THIRDPARTY
+known_first_party=h_cookiecutter_pypackage

--- a/tests/integration/bin/replay_cookie_cutter_test.py
+++ b/tests/integration/bin/replay_cookie_cutter_test.py
@@ -5,7 +5,6 @@ import shutil
 from unittest import mock
 
 import pytest
-
 from bin.replay_cookie_cutter import CookieCutter, run
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ to put fixture functions that are useful application-wide.
 import os
 
 import pytest
-
 from bin.replay_cookie_cutter import CookieCutter
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     lint: pylint {posargs:src bin}
     lint: pylint --rcfile=tests/.pylintrc tests
     format: black {posargs:src tests bin}
-    format: isort --recursive --quiet --atomic .
+    format: isort --recursive --atomic .
     checkformatting: black --check {posargs:src tests bin}
     checkformatting: isort --recursive --quiet --check-only .
     coverage: -coverage combine

--- a/{{ cookiecutter.project_slug }}/.isort.cfg
+++ b/{{ cookiecutter.project_slug }}/.isort.cfg
@@ -1,1 +1,11 @@
-../.isort.cfg
+# A Black (https://github.com/psf/black)-compatible isort
+# (https://timothycrosley.github.io/isort/) config. Copy-pasted from Black's
+# README.
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+default_section=THIRDPARTY
+known_first_party={{ cookiecutter.pkg_name }}


### PR DESCRIPTION
As we don't store our dependencies somewhere isort is expecting, it assumes everything is first party. Much better to make it assume third party and then mention the exceptions.