### PR TITLE
Moving to an auto-incrementing tag based system for versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 
 	@echo "make dist              Create package in the dist/ directory"
+	@echo "make release           Tag a release and trigger deployment to PyPI"
 	@echo "make publish           Publish packages created in the dist/ directory"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
@@ -29,6 +30,10 @@ checkformatting: python
 .PHONY: dist
 dist: python
 	@BUILD=$(BUILD) tox -qe package
+
+.PHONY: release
+release: python
+	@tox -qe release
 
 .PHONY: publish
 publish: python

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,9 @@ help:
 	@echo "make lint              Code quality analysis (pylint)"
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
-	@echo "make dist              Create package in the dist/ directory"
+	@echo "make dist              Create package in the dist/ directory for local testing"
 	@echo "make release           Tag a release and trigger deployment to PyPI"
-	@echo "make re-release        Re-release a tag by specifying VERSION=v.1.x.x etc."
-	@echo "                       This will not overwrite a package in PyPI but can be"
-	@echo "                       useful if the release did not pass CI the first time."
-	@echo "make publish           Publish packages created in the dist/ directory"
+	@echo "make initialrelease    Create the first release of a package"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
 	@echo "make clean             Delete development artefacts (cached files, "
@@ -31,24 +28,15 @@ checkformatting: python
 
 .PHONY: dist
 dist: python
-	@BUILD=$(BUILD) tox -qe package
+	@BUILD=$(BUILD) tox -qe dist
 
 .PHONY: release
 release: python
 	@tox -qe release
 
-.PHONY: re-release
-re-release:
-	@[ -z "$(VERSION)" ] && { echo "No VERSION specified"; exit 1; } || echo "This will delete and remake the tag '$(VERSION)'"
-	@read -p "(Enter to continue, Ctrl-C to quit)" dummy
-	@git tag --delete $(VERSION)
-	@git tag -a $(VERSION)
-	@git push --delete origin $(VERSION)
-	@git push origin $(VERSION) --follow-tags
-
-.PHONY: publish
-publish: python
-	@tox -qe publish
+.PHONY: initialrelease
+initialrelease: python
+	@tox -qe initialrelease
 
 .PHONY: test
 test: python

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ re-release:
 	@[ -z "$(VERSION)" ] && { echo "No VERSION specified"; exit 1; } || echo "This will delete and remake the tag '$(VERSION)'"
 	@read -p "(Enter to continue, Ctrl-C to quit)" dummy
 	@git tag --delete $(VERSION)
-	@git push --delete origin $(VERSION)
 	@git tag -a $(VERSION)
-	@git push --follow-tags
+	@git push --delete origin $(VERSION)
+	@git push origin $(VERSION) --follow-tags
 
 .PHONY: publish
 publish: python

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ help:
 	@echo "make lint              Code quality analysis (pylint)"
 	@echo "make format            Correctly format the code"
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
-
 	@echo "make dist              Create package in the dist/ directory"
 	@echo "make release           Tag a release and trigger deployment to PyPI"
+	@echo "make re-release        Re-release a tag by specifying VERSION=v.1.x.x etc."
+	@echo "                       This will not overwrite a package in PyPI but can be"
+	@echo "                       useful if the release did not pass CI the first time."
 	@echo "make publish           Publish packages created in the dist/ directory"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
@@ -34,6 +36,15 @@ dist: python
 .PHONY: release
 release: python
 	@tox -qe release
+
+.PHONY: re-release
+re-release:
+	@[ -z "$(VERSION)" ] && { echo "No VERSION specified"; exit 1; } || echo "This will delete and remake the tag '$(VERSION)'"
+	@read -p "(Enter to continue, Ctrl-C to quit)" dummy
+	@git tag --delete $(VERSION)
+	@git push --delete origin $(VERSION)
+	@git tag -a $(VERSION)
+	@git push --follow-tags
 
 .PHONY: publish
 publish: python

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For this to work you'll need to setup an API key for the project.
 
 ### Build a package and upload it to PyPI
 
-* Run: `make publish`
+* Run: `make release`
 * Type in a release message for the intial release
 * Run: `tox -e publish --run-command "twine upload -u eng@list.hypothes.is -p <PASSWORD_HERE> dist/*"`
   

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ $ cookiecutter gh:hypothesis/h-cookiecutter-pypackage
 Publishing to PyPI
 ------------------
 
+Once your package is up and running the following behaviour is in place:
+
+ * All pushes will be run through the full set of tests and linting
+ * Only successful tagged builds will be published to PyPI
+    * To do this run `make release`
+
+### The first time
+
 When you merge a pull request into master, if the package passes all tests, coverage, format and linting
 requirements, GitHub Actions will automatically build it and uploaded it to [https://pypi.org/](https://pypi.org/).
 
@@ -32,7 +40,8 @@ For this to work you'll need to setup an API key for the project.
 
 ### Build a package and upload it to PyPI
 
-* Run: `make dist BUILD=0.0`
+* Run: `make publish`
+* Type in a release message for the intial release
 * Run: `tox -e publish --run-command "twine upload -u eng@list.hypothes.is -p <PASSWORD_HERE> dist/*"`
   
 ### Create an API key in PyPI  
@@ -54,8 +63,6 @@ have a single account as maintainer.
 * Use "`PYPI_TOKEN`" as the name
 * Paste the API key in as the value
 * Press <kbd>Add secret</kbd>
-
-Your next successful commit in `master` should now publish to PyPI. 
 
 Hacking
 -------

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Once your package is up and running the following behaviour is in place:
  * Only successful tagged builds will be published to PyPI
     * To do this run `make release`
 
+### I ran `make release` but it went wrong!
+
+If a release fails to build then just run the command again.
+
+This will skip a version number, but that's ok. If you want to you can
+also delete the failed release tag from Github.
+
 ### The first time
 
 When you merge a pull request into master, if the package passes all tests, coverage, format and linting
@@ -40,9 +47,9 @@ For this to work you'll need to setup an API key for the project.
 
 ### Build a package and upload it to PyPI
 
-* Run: `make release`
+* Run: `make initialrelease`
 * Type in a release message for the intial release
-* Run: `tox -e publish --run-command "twine upload -u eng@list.hypothes.is -p <PASSWORD_HERE> dist/*"`
+* Run: `tox -e initialrelease --run-command "twine upload -u eng@list.hypothes.is -p <PASSWORD_HERE> dist/*"`
   
 ### Create an API key in PyPI  
 

--- a/bin/check_that_git_working_tree_is_clean.sh
+++ b/bin/check_that_git_working_tree_is_clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+#
+# Exit with 0 if the current working directory's git working tree is clean,
+# exit with 1 if it's unclean (for example if it contains any untracked files,
+# or any uncommitted changes to tracked files).
+#
+# Usage:
+#
+#     bin/check_that_git_working_tree_is_clean.sh
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo -n "It looks like your git working tree is unclean. "
+    echo -n "Commit or restore any changes, and commit or delete any "
+    echo "untracked files, then try again."
+    exit 1
+fi

--- a/bin/next_version.py
+++ b/bin/next_version.py
@@ -51,5 +51,5 @@ class VersionSuggester:
         return f"v{major_minor}.{build}"
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print(VersionSuggester.suggest_tag())

--- a/bin/next_version.py
+++ b/bin/next_version.py
@@ -1,0 +1,55 @@
+"""Suggest a new tag to make a release with."""
+
+from distutils.errors import DistutilsFileError
+from subprocess import check_output
+
+from packaging import version
+from setuptools.config import read_configuration
+
+
+class VersionSuggester:
+    """Detects various version indicators and suggests a nice next tag"""
+
+    @classmethod
+    def last_tag(cls):
+        """Determine the last tag according to git."""
+
+        tags = check_output(["git", "tag", "--list", "--sort=-v:refname"])
+        if not tags:
+            return None
+
+        last_tag = tags.decode("utf-8").split("\n", 1)[0]
+        return version.parse(last_tag)
+
+    @classmethod
+    def major_minor_version(cls):
+        """Find the major minor declared in the setup.cfg."""
+        try:
+            config = read_configuration("setup.cfg")
+        except DistutilsFileError:
+            raise FileNotFoundError("setup.cfg")
+
+        return version.parse(config["metadata"]["version"])
+
+    @classmethod
+    def suggest_tag(cls):
+        """Suggest a new tag."""
+        major_minor = cls.major_minor_version()
+
+        last_tag = cls.last_tag()
+        if last_tag is None:
+            build = 0
+        elif last_tag.release[:2] == major_minor.release[:2]:
+            build = last_tag.release[2] + 1
+        elif last_tag > major_minor:
+            raise ValueError(
+                f"The last tag 'v{last_tag}' is ahead of the declared version '{major_minor}'"
+            )
+        else:
+            build = 0
+
+        return f"v{major_minor}.{build}"
+
+
+if __name__ == "__main__":
+    print(VersionSuggester.suggest_tag())

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,11 @@ class Package:
         # If we have a build argument we should honour it no matter what
         build = os.environ.get(build_var)
         if build:
-            return self.version + "." + build
+            start = 'v' + self.version + '.'
+            if not build.startswith(start):
+                raise ValueError(f'Expected build to be "{start}*", got "{build}"')
 
+            return self.version + "." + build[len(start):]
         # If not, we should try and read it from the .egg-info/ data
 
         # We need to do this for source distributions, as setup.py is re-run when

--- a/setup.py
+++ b/setup.py
@@ -37,26 +37,53 @@ class Package:
                     return line.strip().split("Version: ")[-1]
 
     def get_version(self, build_var="BUILD"):
-        # If we have a build argument we should honour it no matter what
+        """Gets a version reading from the specified environment variable
+
+        This expects the variable to contain something like:
+
+         * refs/heads/<branch_name> - This will be ignored
+         * refs/tags/v<version> - This will be used if it matches our major
+                                  minor number
+         * v<version> - This will be used if it matches our major minor number
+
+        If this is not present then we will read from the .egg-info/ data if
+        possible.
+
+        Finally a fallback development version is provided.
+
+        :param build_var: The enviroment to
+        :return: A version string
+        """
+        # If we have a build argument we should honour it if we can
         build = os.environ.get(build_var)
         if build:
+            if build.startswith('refs/heads/'):
+                # We are being built via CI from a branch: we'll return a
+                # dummy value marking this as an 'alpha' release
+                return self.version + '.a0'
+
+            if build.startswith('refs/tags/'):
+                # We are being built via CI from a tag: strip the refs stuff
+                build = build.replace('refs/tags/', '')
+
             start = 'v' + self.version + '.'
             if not build.startswith(start):
                 raise ValueError(f'Expected build to be "{start}*", got "{build}"')
 
             return self.version + "." + build[len(start):]
+
         # If not, we should try and read it from the .egg-info/ data
 
-        # We need to do this for source distributions, as setup.py is re-run when
-        # installed this way, and we would always get 'dev0' as the version
-        # Wheels and binary installs don't work this way and read from PKG-INFO
-        # for them selves
+        # We need to do this for source distributions, as setup.py is re-run
+        # when installed this way, and we would always get 'dev0' as the
+        # version wheels and binary installs don't work this way and read
+        # from PKG-INFO for them selves
         egg_version = self.read_egg_version()
         if egg_version:
             return egg_version
 
-        # Otherwise create a 'dev' build which will be counted by pip as 'later'
-        # than the major version no matter what
+        # Otherwise create a 'dev' build which will be counted by pip as
+        # 'later' than the major version no matter what
         return self.version + ".dev0"
 
 

--- a/tests/integration/bin/next_version_test.py
+++ b/tests/integration/bin/next_version_test.py
@@ -1,0 +1,69 @@
+import os
+from unittest.mock import create_autospec
+
+import pytest
+from bin.next_version import VersionSuggester
+from packaging import version
+
+
+class TestVersionSuggester:
+    def test_it_fails_without_setup_cfg(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            VersionSuggester.major_minor_version()
+
+    def test_it_can_read_setup_cfg(self, project_dir):
+        assert VersionSuggester.major_minor_version() == version.parse("1.3")
+
+    def test_it_can_read_git_tag(self, check_output):
+        check_output.return_value = b"v1.0.4\nv1.0.3\nv1.0.2"
+
+        assert VersionSuggester.last_tag() == version.parse("1.0.4")
+
+    def test_it_can_fail_to_read_git_tag_returning_None(self, check_output):
+        check_output.return_value = b""
+
+        assert VersionSuggester.last_tag() is None
+
+    def test_it_suggests_zero_with_no_tag(self, project_dir, VersionSuggester):
+        VersionSuggester.last_tag.return_value = None
+
+        assert VersionSuggester.suggest_tag() == "v1.3.0"
+
+    def test_it_increments_a_matching_tag(self, project_dir, VersionSuggester):
+        VersionSuggester.last_tag.return_value = version.parse("1.3.4")
+
+        assert VersionSuggester.suggest_tag() == "v1.3.5"
+
+    def test_it_jumps_if_tag_is_old(self, project_dir, VersionSuggester):
+        VersionSuggester.last_tag.return_value = version.parse("1.2.4")
+
+        assert VersionSuggester.suggest_tag() == "v1.3.0"
+
+    def test_it_crashes_if_tag_is_newer(self, project_dir, VersionSuggester):
+        VersionSuggester.last_tag.return_value = version.parse("1.5.4")
+
+        with pytest.raises(ValueError):
+            VersionSuggester.suggest_tag()
+
+    @pytest.fixture
+    def check_output(self, patch):
+        return patch("bin.next_version.check_output")
+
+    @pytest.fixture()
+    def VersionSuggester(self, patch):
+        class TestableSuggester(VersionSuggester):
+            last_tag = create_autospec(VersionSuggester.last_tag)
+
+        return TestableSuggester
+
+    @pytest.fixture
+    def project_dir(self, tmpdir):
+        current_dir = os.getcwd()
+
+        try:
+            tmpdir.join("setup.cfg").write("[metadata]\nversion = 1.3\n")
+
+            os.chdir(tmpdir)
+            yield tmpdir
+        finally:
+            os.chdir(current_dir)

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -29,12 +29,12 @@ class TestBuildFunctions:
         results = self.assert_run_command_ok(
             ["python", "setup.py", "sdist"],
             cwd=existing_project,
-            env={"BUILD": "1234.5678"},
+            env={"BUILD": "v1.0.5678"},
         )
 
         # This is the last step in the build
-        assert "removing 'h_test_lib-1.0.1234.5678'" in results.decode("utf-8")
-        expected_artifact = "h_test_lib-1.0.1234.5678.tar.gz"
+        assert "removing 'h_test_lib-1.0.5678'" in results.decode("utf-8")
+        expected_artifact = "h_test_lib-1.0.5678.tar.gz"
 
         assert expected_artifact in os.listdir(os.path.join(existing_project, "dist"))
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,26 +24,42 @@ deps =
     {checkformatting,format}: black
     {checkformatting,format}: isort[requirements]
     coverage: coverage
-    {package,publish}: twine
-    package: wheel
+    {package,release,publish}: twine
+    {package,release,publish}: wheel
     {lint,replay-cookiecutter}: cookiecutter
+    release: packaging
 whitelist_externals =
-    package: rm
+    {package,release}: rm
+    release: sh
+    release: git
 commands =
     tests: coverage run -m pytest tests
+
     lint: pydocstyle --explain src
     lint: pydocstyle --config tests/.pydocstyle --explain tests
     lint: pylint {posargs:src bin}
     lint: pylint --rcfile=tests/.pylintrc tests
+
     format: black {posargs:src tests bin}
     format: isort --recursive --atomic .
+
     checkformatting: black --check {posargs:src tests bin}
     checkformatting: isort --recursive --quiet --check-only .
+
     coverage: -coverage combine
     coverage: coverage report
+
     package: rm -rf dist src/*.egg-info
     package: python setup.py bdist_wheel sdist
     package: twine check dist/*
+
+    release: rm -rf dist src/*.egg-info
+    release: sh -c "BUILD=`python bin/next_version.py` python setup.py bdist_wheel sdist"
+    release: twine check dist/*
+    release: sh -c "git tag -a `python bin/next_version.py`"
+    release: git push --follow-tags
+
     publish: twine check dist/*
     publish: twine upload dist/*
+
     replay-cookiecutter: python bin/replay_cookie_cutter.py --config .cookiecutter.json --output-directory .

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     {checkformatting,format}: black
     {checkformatting,format}: isort[requirements]
     coverage: coverage
+    {release,initialrelease}: packaging
     {dist,initialrelease}: twine
     {dist,initialrelease}: wheel
     {lint,replay-cookiecutter}: cookiecutter

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,11 @@ tox_pyenv_fallback = false
 
 [testenv]
 skip_install = true
-sitepackages = {env:SITE_PACKAGES:false}
+sitedists = {env:SITE_PACKAGES:false}
 setenv = dev: PYTHONPATH = .
 passenv =
     HOME
-    package: BUILD
+    dist: BUILD
 deps =
     {tests,lint}: .[tests]
     lint: pylint
@@ -24,15 +24,15 @@ deps =
     {checkformatting,format}: black
     {checkformatting,format}: isort[requirements]
     coverage: coverage
-    {package,release,publish}: twine
-    {package,release,publish}: wheel
+    {dist,initialrelease}: twine
+    {dist,initialrelease}: wheel
     {lint,replay-cookiecutter}: cookiecutter
     release: packaging
 whitelist_externals =
     release: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
-    {package,release}: rm
-    release: sh
-    release: git
+    {dist,initialrelease}: rm
+    {release,initialrelease}: sh
+    {release,initialrelease}: git
 commands =
     tests: coverage run -m pytest tests
 
@@ -50,18 +50,12 @@ commands =
     coverage: -coverage combine
     coverage: coverage report
 
-    package: rm -rf dist src/*.egg-info
-    package: python setup.py bdist_wheel sdist
-    package: twine check dist/*
-
-    release: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
-    release: rm -rf dist src/*.egg-info
-    release: sh -c "BUILD=`python bin/next_version.py` python setup.py bdist_wheel sdist"
-    release: twine check dist/*
-    release: sh -c "git tag -a `python bin/next_version.py`"
-    release: git push --follow-tags
-
-    publish: twine check dist/*
-    publish: twine upload dist/*
+    {release,initialrelease}: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
+    {dist,initialrelease}: rm -rf dist src/*.egg-info
+    initialrelease: sh -c "BUILD=`python bin/next_version.py` python setup.py bdist_wheel sdist"
+    dist: python setup.py bdist_wheel sdist
+    {dist,initialrelease}: twine check dist/*
+    {release,initialrelease}: sh -c "git tag -a `python bin/next_version.py`"
+    {release,initialrelease}: git push git@github.com:hypothesis/h-cookiecutter-pypackage.git --follow-tags
 
     replay-cookiecutter: python bin/replay_cookie_cutter.py --config .cookiecutter.json --output-directory .

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ tox_pyenv_fallback = false
 
 [testenv]
 skip_install = true
-sitedists = {env:SITE_PACKAGES:false}
+sitepackages = {env:SITE_PACKAGES:false}
 setenv = dev: PYTHONPATH = .
 passenv =
     HOME

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     {lint,replay-cookiecutter}: cookiecutter
     release: packaging
 whitelist_externals =
+    release: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
     {package,release}: rm
     release: sh
     release: git
@@ -53,6 +54,7 @@ commands =
     package: python setup.py bdist_wheel sdist
     package: twine check dist/*
 
+    release: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
     release: rm -rf dist src/*.egg-info
     release: sh -c "BUILD=`python bin/next_version.py` python setup.py bdist_wheel sdist"
     release: twine check dist/*

--- a/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
@@ -10,6 +10,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Show git ref
+      run: |
+        echo ${% raw %}{{ github.ref }}{% endraw %}
+
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/pythonpackage.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Package
       run: |
         pip install twine wheel
-        BUILD=`date +%Y%m%d.%H%M%S` python setup.py bdist_wheel sdist
+        BUILD=${% raw %}{{ github.ref }}{% endraw %} python setup.py bdist_wheel sdist
         twine check dist/*
 
     - name: Archive packages
@@ -96,7 +96,7 @@ jobs:
     name: Publish
     needs: package
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Download built packages

--- a/{{ cookiecutter.project_slug }}/bin/check_that_git_working_tree_is_clean.sh
+++ b/{{ cookiecutter.project_slug }}/bin/check_that_git_working_tree_is_clean.sh
@@ -1,0 +1,1 @@
+../../bin/check_that_git_working_tree_is_clean.sh

--- a/{{ cookiecutter.project_slug }}/bin/next_version.py
+++ b/{{ cookiecutter.project_slug }}/bin/next_version.py
@@ -1,0 +1,1 @@
+../../bin/next_version.py

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -12,7 +12,7 @@ tox_pyenv_fallback = false
 
 [testenv]
 skip_install = true
-sitedists = {env:SITE_PACKAGES:false}
+sitepackages = {env:SITE_PACKAGES:false}
 setenv = dev: PYTHONPATH = .
 passenv =
     HOME
@@ -24,6 +24,7 @@ deps =
     {checkformatting,format}: black
     {checkformatting,format}: isort[requirements]
     coverage: coverage
+    {release,initialrelease}: packaging
     {dist,initialrelease}: twine
     {dist,initialrelease}: wheel
     {lint,replay-cookiecutter}: cookiecutter

--- a/{{ cookiecutter.project_slug }}/tox.ini
+++ b/{{ cookiecutter.project_slug }}/tox.ini
@@ -1,1 +1,61 @@
-../tox.ini
+[tox]
+envlist = py36-tests
+skipsdist = true
+minversion = 3.8.0
+requires =
+  tox-pip-extensions
+  tox-pyenv
+  tox-envfile
+  tox-run-command
+tox_pip_extensions_ext_venv_update = true
+tox_pyenv_fallback = false
+
+[testenv]
+skip_install = true
+sitedists = {env:SITE_PACKAGES:false}
+setenv = dev: PYTHONPATH = .
+passenv =
+    HOME
+    dist: BUILD
+deps =
+    {tests,lint}: .[tests]
+    lint: pylint
+    lint: pydocstyle
+    {checkformatting,format}: black
+    {checkformatting,format}: isort[requirements]
+    coverage: coverage
+    {dist,initialrelease}: twine
+    {dist,initialrelease}: wheel
+    {lint,replay-cookiecutter}: cookiecutter
+    release: packaging
+whitelist_externals =
+    release: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
+    {dist,initialrelease}: rm
+    {release,initialrelease}: sh
+    {release,initialrelease}: git
+commands =
+    tests: coverage run -m pytest tests
+
+    lint: pydocstyle --explain src
+    lint: pydocstyle --config tests/.pydocstyle --explain tests
+    lint: pylint {posargs:src bin}
+    lint: pylint --rcfile=tests/.pylintrc tests
+
+    format: black {posargs:src tests bin}
+    format: isort --recursive --atomic .
+
+    checkformatting: black --check {posargs:src tests bin}
+    checkformatting: isort --recursive --quiet --check-only .
+
+    coverage: -coverage combine
+    coverage: coverage report
+
+    {release,initialrelease}: {toxinidir}/bin/check_that_git_working_tree_is_clean.sh
+    {dist,initialrelease}: rm -rf dist src/*.egg-info
+    initialrelease: sh -c "BUILD=`python bin/next_version.py` python setup.py bdist_wheel sdist"
+    dist: python setup.py bdist_wheel sdist
+    {dist,initialrelease}: twine check dist/*
+    {release,initialrelease}: sh -c "git tag -a `python bin/next_version.py`"
+    {release,initialrelease}: git push git@github.com:hypothesis/{{ cookiecutter.project_slug }}.git --follow-tags
+
+    replay-cookiecutter: python bin/replay_cookie_cutter.py --config .cookiecutter.json --output-directory .


### PR DESCRIPTION
This introduces a number of fairly major changes to how the versions work:

 * A new `make release` action has been added which:
   * Looks for existing tags and increments the last one found matching the current major minor
   * If no tag can be found then we assume `.0` on the end
   * You will then be asked for a message describing the release
   * This is then created as a git tag and pushed
 * There is now a `make re-release` which will re-issue the tag incase it didn't build right
 * setup.py now expects the BUILD to match 'v{major}.{minor}.*' or 'refs/tags/v{major}.{minor}.*'

**NOTE:** This will not currently work, as the github action will not pass a build that setup.py will accept.

Todo:

 * [x] - Allow tests etc. to run if no tag was made - _Doesn't use the tag at all_
 * [x] - Allow the packaging step to run if no tag was made
 * [x] - Change the publish step to only run if a tag was made
 * ~~Make the local build read from the tag if present~~ This is a bad idea. There's no good reason for local builds to have a version at all. We can easily make new tags with 'make release' or replay old ones with 'make re-release'