### PR TITLE
Reading requirements from both setup.cfg and requirements.txt

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -10,6 +10,7 @@
             "setup.cfg",
             ".coveragerc",
             "pytest.ini",
+            "requirements.*",
             ".github/*"
         ]
     },

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 # Make sure source distributions have the license
 include LICENSE
-
+include requirements.txt
 include src/h_cookiecutter_pypackage/data_present.txt

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
         "disable_replay": [
             "README.md",
             "setup.cfg",
+            "requirements.*",
             "src/{{ cookiecutter.pkg_name }}/__init__.py"
         ]
     }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,6 @@
+# Put your test dependencies here for dependabot
+
+cookiecutter
+twine
+pytest
+coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
--e .
+# Put your install dependencies here for dependabot
+flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # Put your install dependencies here for dependabot
-flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ license=License :: OSI Approved :: BSD License
 platforms=Operating System :: OS Independent
 
 [options]
-install_requires =
+# List your main requirements in "requirements.txt" for dependabot
 tests_require=
     cookiecutter
     twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,12 +21,3 @@ project_urls=
     Source=https://github.com/hypothesis/{{ cookiecutter.project_slug }}
 license=License :: OSI Approved :: BSD License
 platforms=Operating System :: OS Independent
-
-[options]
-# List your main requirements in "requirements.txt" for dependabot
-tests_require=
-    cookiecutter
-    twine
-    pytest
-    coverage
-

--- a/setup.py
+++ b/setup.py
@@ -6,25 +6,39 @@ from setuptools.config import read_configuration
 
 class Package:
     def __init__(self, config):
-        metadata = config['metadata']
-        options = config['options']
+        metadata = config["metadata"]
+        options = config["options"]
 
         self.options = options
-        self.name = metadata['name']
-        self.version = metadata['version']
+        self.name = metadata["name"]
+        self.version = metadata["version"]
 
     def tests_require(self):
-        return self.options['tests_require'] + self.options['install_requires']
+        return self.options["tests_require"] + self.install_requires()
+
+    def install_requires(self):
+        requirements = self.options.get("install_requires", [])
+        requirements.extend(self.read_requirements_txt())
+        return requirements
+
+    def read_requirements_txt(self):
+        with open("requirements.txt") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#") or line.startswith("-"):
+                    continue
+
+                yield line
 
     def read_egg_version(self):
         pkg_info_file = None
         # PKG-INFO can be in different places depending on whether we are a
         # source distribution or a checked out copy etc.
         for location in [
-                'PKG-INFO',
-                'src/' + self.name + ".egg-info/PKG-INFO",
-                self.name + ".egg-info/PKG-INFO",
-            ]:
+            "PKG-INFO",
+            "src/" + self.name + ".egg-info/PKG-INFO",
+            self.name + ".egg-info/PKG-INFO",
+        ]:
             if os.path.isfile(location):
                 pkg_info_file = location
 
@@ -57,21 +71,19 @@ class Package:
         return self.version + ".dev0"
 
 
-package = Package(read_configuration('setup.cfg'))
+package = Package(read_configuration("setup.cfg"))
 
 setup(
     # Metadata
     # https://docs.python.org/3/distutils/setupscript.html#additional-meta-data
     version=package.get_version(),
-
     # Contents and dependencies
-    packages=find_packages(where='src'),
-    package_dir={'': 'src'},
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
     # Read the MANIFEST.in
     include_package_data=True,
-
     # Add support for pip install .[tests]
     extras_require={"tests": package.tests_require()},
-
     tests_require=package.tests_require(),
+    install_requires=package.install_requires(),
 )

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,12 @@ class Package:
         self.version = metadata["version"]
 
     def tests_require(self):
-        requirements = self.options.get("tests_require", []) + self.install_requires()
+        requirements = self.install_requires()
         requirements.extend(self.read_requirements_file("requirements.test.txt"))
         return requirements
 
     def install_requires(self):
-        requirements = self.options.get("install_requires", [])
-        requirements.extend(self.read_requirements_file("requirements.txt"))
-        return requirements
+        return list(self.read_requirements_file("requirements.txt"))
 
     def read_requirements_file(self, filename):
         with open(filename) as handle:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ class Package:
         self.version = metadata["version"]
 
     def tests_require(self):
-        requirements = self.options["tests_require"] + self.install_requires()
-        requirements.extend(self.read_requirements_file("requirements.test.txt")
+        requirements = self.options.get("tests_require", []) + self.install_requires()
+        requirements.extend(self.read_requirements_file("requirements.test.txt"))
         return requirements
 
     def install_requires(self):

--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,17 @@ class Package:
         self.version = metadata["version"]
 
     def tests_require(self):
-        return self.options["tests_require"] + self.install_requires()
+        requirements = self.options["tests_require"] + self.install_requires()
+        requirements.extend(self.read_requirements_file("requirements.test.txt")
+        return requirements
 
     def install_requires(self):
         requirements = self.options.get("install_requires", [])
-        requirements.extend(self.read_requirements_txt())
+        requirements.extend(self.read_requirements_file("requirements.txt"))
         return requirements
 
-    def read_requirements_txt(self):
-        with open("requirements.txt") as handle:
+    def read_requirements_file(self, filename):
+        with open(filename) as handle:
             for line in handle:
                 line = line.strip()
                 if not line or line.startswith("#") or line.startswith("-"):

--- a/{{ cookiecutter.project_slug }}/MANIFEST.in
+++ b/{{ cookiecutter.project_slug }}/MANIFEST.in
@@ -1,2 +1,3 @@
 # Make sure source distributions have the license
 include LICENSE
+include requirements.txt

--- a/{{ cookiecutter.project_slug }}/requirements.test.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.test.txt
@@ -1,0 +1,1 @@
+# Put your test dependencies here for dependabot

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -21,10 +21,3 @@ project_urls=
     Source=https://github.com/hypothesis/h-cookiecutter-pypackage
 license=License :: OSI Approved :: BSD License
 platforms=Operating System :: OS Independent
-
-[options]
-# List your main requirements in "requirements.txt" for dependabot
-tests_require=
-    pytest
-    coverage
-

--- a/{{ cookiecutter.project_slug }}/setup.cfg
+++ b/{{ cookiecutter.project_slug }}/setup.cfg
@@ -23,7 +23,7 @@ license=License :: OSI Approved :: BSD License
 platforms=Operating System :: OS Independent
 
 [options]
-install_requires =
+# List your main requirements in "requirements.txt" for dependabot
 tests_require=
     pytest
     coverage


### PR DESCRIPTION
This means we can put requirements in requirements.txt which dependabot
will understand, but we don't explode anyone with settings in setup.cfg
right away. This gives a nice way to migrate when ready.

You can test this is working by putting a requirement in the file and then doing:

 * `python setup.py sdist bdist_wheel`
 * For the wheel:
   * Create a fresh virtual env or wipe one
   * `pip install dist/*.whl`
   * `pip freeze`
   * You should see your requirement
 * For the source dist:
   * Create a fresh virtual env or wipe one
   * `pip install dist/*.tar.gz`
   * `pip freeze`
   * You should see your requirement

TODO:

 - [ ] Move test requirements into a `requirements.test.txt` for dependabot